### PR TITLE
Fix an issue with range sliders

### DIFF
--- a/src/lib/IntroDialog.svelte
+++ b/src/lib/IntroDialog.svelte
@@ -94,7 +94,7 @@
             min={pixelSizeMin}
             max={pixelSizeMax}
             value={height}
-            on:sl-change={(e) => (height = e.target.__value)}
+            on:sl-change={(e) => (height = e.target.value)}
           >
             <div slot="label" class="pb-1 text-sm font-semibold text-gray-500">
               Height
@@ -112,7 +112,7 @@
             min={pixelSizeMin}
             max={pixelSizeMax}
             value={width}
-            on:sl-change={(e) => (width = e.target.__value)}
+            on:sl-change={(e) => (width = e.target.value)}
           >
             <div slot="label" class="pb-1 text-sm font-semibold text-gray-500">
               Width
@@ -125,7 +125,7 @@
       </div>
 
       <div class="pt-3 text-sm font-semibold text-gray-500">
-        Maximum layers is <span class="text-gray-600 font-bold">{maxLayerCount}</span>
+        Maximum layers are <span class="text-gray-600 font-bold">{maxLayerCount}</span>
       </div>
     {/if}
 

--- a/src/lib/LayersPanel.svelte
+++ b/src/lib/LayersPanel.svelte
@@ -100,7 +100,7 @@
 
       const firstIndex = $myPresence.selectedLayer;
       const oldLayer = $layerStorage.get("" + firstIndex);
-      const newLayer = { ...oldLayer, opacity: target.__value / 100 };
+      const newLayer = { ...oldLayer, opacity: target.value / 100 };
       $layerStorage.set("" + $myPresence.selectedLayer, newLayer);
     },
     100,


### PR DESCRIPTION
At the moment the range sliders don't work:

![CleanShot 2024-06-13 at 14 14 15@2x](https://github.com/liveblocks/pixel-art-together/assets/5033092/e16e39a5-39c1-4272-968c-915c9d5bcb73)

After this change they do:

![CleanShot 2024-06-13 at 14 14 40@2x](https://github.com/liveblocks/pixel-art-together/assets/5033092/cb566404-5018-4246-9f9c-ef61a87e0702)

Also included a very minor text change.